### PR TITLE
Fix JQuery chaining

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -967,7 +967,7 @@
     ;
     return (returnedValue !== undefined)
       ? returnedValue
-      : $allModules
+      : this
       ;
   };
 


### PR DESCRIPTION
Returning a new instance of jquery breaks a .find().calendar().end() chain