### PR TITLE
Add cell formatter

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -302,6 +302,23 @@
                     if (!isHour && !isMinute) {
                       cell.toggleClass(className.todayCell, !adjacent && module.helper.dateEqual(cellDate, today, mode));
                     }
+
+                    // Allow for external modifications of each cell
+                    var type = 'year';
+                    if (isMonth) { type = 'month'; }
+                    if (isDay) { type = 'day'; }
+                    if (isHour) { type = 'hour'; }
+                    if (isMinute) { type = 'minute'; }
+
+                    var cellOptions = {
+                        type: type,
+                        adjacent: adjacent,
+                        disabled: disabled,
+                        active: active
+                    };
+
+                    formatter.cell(cell, cellDate, cellOptions);
+
                     if (module.helper.dateEqual(cellDate, focusDate, mode)) {
                       //ensure that the focus date is exactly equal to the cell date
                       //so that, if selected, the correct value is set
@@ -1085,6 +1102,8 @@
       },
       today: function (settings) {
         return settings.type === 'date' ? settings.text.today : settings.text.now;
+      },
+      cell: function (cell, date, cellOptions) {
       }
     },
 

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -314,7 +314,8 @@
                         type: type,
                         adjacent: adjacent,
                         disabled: disabled,
-                        active: active
+                        active: active,
+                        today: module.helper.dateEqual(cellDate, today, mode)
                     };
 
                     formatter.cell(cell, cellDate, cellOptions);


### PR DESCRIPTION
Add a "cell" formatter callback to allow for direct manipulation of each individual cell in a calendar or time picker.

The `cell` argument is the cell element, the `date` argument is the Date Object representing that cell and the `cellOptions` argument is an object containing the cell types being displayed, and whether the cell is adjacent, disabled or active.

JSBin example here: http://jsbin.com/hafenikefi/edit?html,css,js,output

In the example above, I use the cell formatter to highlight the public holidays in Australia.