### PR TITLE
added a main file for easier module importing

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require("./dist/calendar.js");

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "semantic-ui-calendar",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Calendar module for Semantic UI",
   "author": "Michael de Hoog (https://github.com/mdehoog/)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mdehoog/semantic-ui-calendar.git"
+    "url": "git+https://github.com/mdehoog/semantic-ui-calendar.git"
   },
   "license": "MIT",
   "devDependencies": {
@@ -20,5 +20,13 @@
     "gulp-uglify": "^2.0.0",
     "require-dot-file": "^0.4.0",
     "semantic-ui-less": "^2.2.4"
+  },
+  "bugs": {
+    "url": "https://github.com/mdehoog/semantic-ui-calendar/issues"
+  },
+  "homepage": "https://github.com/mdehoog/semantic-ui-calendar#readme",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
   }
 }


### PR DESCRIPTION
This will make it easier to import the module in project

so instead of
```javascript
require("semantic-ui-calendar/dist/calendar.js");
```
it will be
```javascript
require("semantic-ui-calendar");
```

though importing CSS will be the same, devs need to write the full relative path
```css
@import "semantic-ui-calendar/dist/calendar.css";
```